### PR TITLE
GUI implementation of visualization improvements + plotting of seed voxel

### DIFF
--- a/libs/haufe/allplots_cortex_BS.m
+++ b/libs/haufe/allplots_cortex_BS.m
@@ -25,8 +25,9 @@ else
     end
 end
 
-cortex.Vertices = cortex.Vertices(:, [2 1 3]);
-cortex.Vertices(:, 1) = -cortex.Vertices(:, 1);
+% coordinate transformation
+% cortex.Vertices = cortex.Vertices(:, [2 1 3]);
+% cortex.Vertices(:, 1) = -cortex.Vertices(:, 1);
 
 
 for iatl = 1:length(cortex.Atlas)

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -470,7 +470,7 @@ end
 % function [coordinate, seed_idx] = get_seedregion_coordinate(seed_region, vc)
 function [coordinate, seed_idx] = get_seedregion_coordinate(scouts, seed_idx, vc)
     % determine voxel of selected seed region, if needed
-    % assign region index to selected seed region (passed as string)
+    % assign region index to selected seed region (passed as index)
 %     cortex_struct = struct2cell(a);
 %     seed_idx = find(contains(cortex_struct(4,:,:), seed_region));
     if ~isempty(seed_idx)

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -11,20 +11,28 @@
 %  'sourcemodel' - [string] source model file
 %
 % Optional inputs:
-%  'measure'    - ['psd'|'roipsd'|'trgc'|'crossspecimag'|'crossspecpow'|'mic'|'mim']
-%                   'psd'   : Source power spectrum
-%                   'psdroi': ROI based power spectrum
-%                   'trgc'  : Time-reversed granger causality
-%                   'crossspecimag': Imaginary part of coherence from cross-spectrum
-%                   'crossspecpow' : Average cross-spectrum power for each ROI
-%                   'mic' : Maximized Imaginary Coherency for each ROI
-%                   'mim' : Multivariate Interaction Measure for each ROI
-%  'freqrange'  - [min max] frequency range in Hz. Default is to plot
-%                 broadband power.
-%  'smooth'     - [float] smoothing factor for cortex surface plotting
-%  'plotcortex' - ['on'|'off'] plot results on smooth cortex. Default is 'on'
-%  'plotmatrix' - ['on'|'off'] plot results on smooth cortex. Default is 'off'
-%  'plotpsd'    - ['on'|'off'] plot PSD (for 'crossspecpow' only). Default is 'off'
+%  'measure'              - ['psd'|'roipsd'|'trgc'|'crossspecimag'|'crossspecpow'|'mic'|'mim']
+%                           'psd'   : Source power spectrum
+%                           'psdroi': ROI based power spectrum
+%                           'trgc'  : Time-reversed granger causality
+%                           'gc'    : Granger causality
+%                           'crossspecimag': Imaginary part of coherence from cross-spectrum
+%                           'crossspecpow' : Average cross-spectrum power for each ROI
+%                           'mic' : Maximized Imaginary Coherency for each ROI
+%                           'mim' : Multivariate Interaction Measure for each ROI
+%  'freqrange'            - [min max] frequency range in Hz. Default is to plot broadband power.
+%  'smooth'               - [float] smoothing factor for cortex surface plotting
+%  'plotcortex'           - ['on'|'off'] plot results on smooth cortex. Default is 'on'
+%  'plotcortexparams'     - [cell] ...
+%  'plotcortexseedregion' - [string] plot seed voxel on cortex. Takes name of seed region as input.
+%  'plot3d'               - ['on'|'off'] ... Default is 'off'
+%  'plot3dparams'         - [cell] ...
+%  'plotmatrix'           - ['on'|'off'] plot results as ROI to ROI matrix. Default is 'off'
+%  'plotbarplot'          - ['on'|'off'] plot ROI based power spectrum as barplot. Default is 'off'
+%  'hemisphere'           - ['all'|'left'|'right'] hemisphere options for ROI to ROI matrix. Default is 'all'
+%  'region'               - ['all'|'cingulate'|'prefrontal'|'frontal'|'temporal'|'parietal'|'central'|'occipital'] region selection for ROI to ROI matrix. Default is 'all'
+%  'largeplot'            - ['on'|'off'] plot MIM, TRGC and Power in a single large plot. Default is 'off'
+%  'plotpsd'              - ['on'|'off'] plot PSD (for 'crossspecpow' only). Default is 'off'
 %
 % Author: Stefan Haufe and Arnaud Delorme, 2019
 %

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -285,7 +285,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
         MI = get_connect_mat( MI, S.nROI, +1);
         MIM_matrix = squeeze(mean(MI(frq_inds, :, :)));
         
-        pltlarge(EEG, MIM_matrix, TRGC_matrix, source_roi_power_norm_dB, titleStr)
+        roi_largeplot(EEG, MIM_matrix, TRGC_matrix, source_roi_power_norm_dB, titleStr)
     else     
         switch lower(g.measure)
             case { 'psd' 'roipsd' }
@@ -307,7 +307,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
 
                 if strcmpi(g.plotbarplot, 'on')
                     source_roi_power_norm_dB = 10*log10( mean(EEG.roi.source_roi_power(frq_inds,:)) );
-                    pltmatrix(EEG, source_roi_power_norm_dB, titleStr, g.measure, g.hemisphere, g.region);
+                    roi_plotcoloredlobes(EEG, source_roi_power_norm_dB, titleStr, g.measure, g.hemisphere, g.region);
                 end
 
             case { 'trgc' 'gc' }
@@ -328,7 +328,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
 
                 if strcmpi(g.plotmatrix, 'on')
                     matrix = squeeze(mean(TRGC(frq_inds, :, :)));
-                    pltmatrix(EEG, matrix, titleStr, g.measure, g.hemisphere, g.region);
+                    roi_plotcoloredlobes(EEG, matrix, titleStr, g.measure, g.hemisphere, g.region);
                 end
 
                 if strcmpi(g.plot3d, 'on')
@@ -353,7 +353,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
 
                 if strcmpi(g.plotmatrix, 'on')
                     matrix = squeeze(mean(MI(frq_inds, :, :)));
-                    pltmatrix(EEG, matrix, titleStr, g.measure, g.hemisphere, g.region);
+                    roi_plotcoloredlobes(EEG, matrix, titleStr, g.measure, g.hemisphere, g.region);
                 end
 
                 if strcmpi(g.plotcortex, 'on')
@@ -428,7 +428,7 @@ function measure = get_connect_mat( measureOri, nROI, signVal)
     end
 end
         
-function pltmatrix( EEG, matrix, titleStr, measure, hemisphere, region)
+function roi_plotcoloredlobes( EEG, matrix, titleStr, measure, hemisphere, region)
     % plot individual ROI to ROI matrix with colored labels (corresponding lobes/regions)
     load cm17
     switch lower(measure)
@@ -575,7 +575,7 @@ function pltmatrix( EEG, matrix, titleStr, measure, hemisphere, region)
     end
 end 
 
-function pltlarge(EEG, mim, trgc, roipsd, titleStr)
+function roi_largeplot(EEG, mim, trgc, roipsd, titleStr)
     % plot MIM, TRGC and power (barplot) in a single large figure
     load cm17
     

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -245,7 +245,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
         options = { options{:} 'plotpsd'    fastif(outs.psd   , 'on', 'off') };
         options = { options{:} 'plot3d'     fastif(outs.plot3d, 'on', 'off') };
         options = { options{:} 'plot3dparams' eval( [ '{' outs.plot3dparams '}' ] ) };
-        options = { options{:} 'region' fcregions{result{9}} };
+        options = { options{:} 'region' fcregions{result{8}} };
         % choose which hemisphere to plot
         if outs.hemisphere_left == 1 && outs.hemisphere_right == 0
             options = { options{:} 'hemisphere' 'left' };
@@ -365,10 +365,12 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
                     if isempty(g.plotcortexseedregion)
                         atrgc = mean(squeeze(mean(TRGC(frq_inds, :, :))), 2);
                         allplots_cortex_BS(S.cortex, atrgc, [-max(abs(atrgc)) max(abs(atrgc))], cm17, upper(g.measure), g.smooth);
+                        movegui(gcf, 'south')
                     else
                         [coordinate, seed_idx] = get_seedregion_coordinate(EEG.roi.atlas.Scouts, g.plotcortexseedregion, EEG.roi.cortex.Vertices);
                         atrgc = squeeze(mean(TRGC(frq_inds, seed_idx, :)));
                         allplots_cortex_BS(S.cortex, atrgc, [-max(abs(atrgc)) max(abs(atrgc))], cm17, upper(g.measure), g.smooth, [], {coordinate});
+                        movegui(gcf, 'south')
                     end
                     h = textsc([ upper(g.measure) ' (' titleStr '); Red = net sender; Blue = net receiver' ], 'title');
                     set(h, 'fontsize', 20);

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -341,6 +341,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
                     allplots_cortex_BS(S.cortex, atrgc, [-max(abs(atrgc)) max(abs(atrgc))], cm17, upper(g.measure), g.smooth);
                     h = textsc([ upper(g.measure) ' (' titleStr '); Red = net sender; Blue = net receiver' ], 'title');
                     set(h, 'fontsize', 20);
+                    movegui(gcf, 'south')
                 end
 
             case { 'mim' 'mic' }

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -265,7 +265,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
         'smooth'                'real'     { }                     0.35;
         'plotcortex'            'string'   { 'on' 'off' }          'on';
         'plotcortexparams'      'cell'     { }                     {};
-        'plotcortexseedregion'  'integer'   { }                     [];
+        'plotcortexseedregion'  'integer'  { }                     [];
         'plot3d'                'string'   { 'on' 'off' }          'off';
         'plot3dparams'          'cell'     { }                     {};
         'plotmatrix'            'string'   { 'on' 'off' }          'off';
@@ -366,7 +366,7 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
                         atrgc = mean(squeeze(mean(TRGC(frq_inds, :, :))), 2);
                         allplots_cortex_BS(S.cortex, atrgc, [-max(abs(atrgc)) max(abs(atrgc))], cm17, upper(g.measure), g.smooth);
                     else
-                        [coordinate, seed_idx] = get_seedregion_coordinate(g.plotcortexseedregion, EEG.roi.cortex.Vertices);
+                        [coordinate, seed_idx] = get_seedregion_coordinate(EEG.roi.atlas.Scouts, g.plotcortexseedregion, EEG.roi.cortex.Vertices);
                         atrgc = squeeze(mean(TRGC(frq_inds, seed_idx, :)));
                         allplots_cortex_BS(S.cortex, atrgc, [-max(abs(atrgc)) max(abs(atrgc))], cm17, upper(g.measure), g.smooth, [], {coordinate});
                     end
@@ -391,12 +391,10 @@ function [matrix, com] = pop_roi_connectplot(EEG, varargin)
                     if isempty(g.plotcortexseedregion)
                         ami = mean(squeeze(mean(MI(frq_inds, :, :))), 2);
                         allplots_cortex_BS(S.cortex, ami, [min(ami) max(ami)], cm17a, upper(g.measure), g.smooth);
-                        movegui(gcf, 'south')
                     else
-                        [coordinate, seed_idx] = get_seedregion_coordinate(g.plotcortexseedregion, EEG.roi.cortex.Vertices);
+                        [coordinate, seed_idx] = get_seedregion_coordinate(EEG.roi.atlas.Scouts, g.plotcortexseedregion, EEG.roi.cortex.Vertices);
                         ami = squeeze(mean(MI(frq_inds, seed_idx,:)));
                         allplots_cortex_BS(S.cortex, ami, [min(ami) max(ami)], cm17a, upper(g.measure), g.smooth, [], {coordinate});
-                        movegui(gcf, 'south')
                     end
                     h = textsc([ upper(g.measure) ' (' titleStr ') '], 'title');
                     set(h, 'fontsize', 20);
@@ -468,14 +466,13 @@ function measure = get_connect_mat( measureOri, nROI, signVal)
 end
 
 % function [coordinate, seed_idx] = get_seedregion_coordinate(seed_region, vc)
-function [coordinate, seed_idx] = get_seedregion_coordinate(seed_idx, vc)
+function [coordinate, seed_idx] = get_seedregion_coordinate(scouts, seed_idx, vc)
     % determine voxel of selected seed region, if needed
     % assign region index to selected seed region (passed as string)
-    load cortex
 %     cortex_struct = struct2cell(a);
 %     seed_idx = find(contains(cortex_struct(4,:,:), seed_region));
     if ~isempty(seed_idx)
-        pos_idx = a(seed_idx).Vertices;
+        pos_idx = scouts(seed_idx).Vertices;
         pos = vc(pos_idx,:);
         mid_point = mean(pos,1);
         [~,closest_pos_idx] = min(eucl(mid_point, pos));

--- a/pop_roi_connectplot.m
+++ b/pop_roi_connectplot.m
@@ -467,18 +467,24 @@ function measure = get_connect_mat( measureOri, nROI, signVal)
     end
 end
 
-% function [coordinate, seed_idx] = get_seedregion_coordinate(seed_region, vc)
 function [coordinate, seed_idx] = get_seedregion_coordinate(scouts, seed_idx, vc)
     % determine voxel of selected seed region, if needed
     % assign region index to selected seed region (passed as index)
-%     cortex_struct = struct2cell(a);
-%     seed_idx = find(contains(cortex_struct(4,:,:), seed_region));
     if ~isempty(seed_idx)
+        % ball not visible for these regions when plotting the mean voxel
+        manual_region_idxs = [2, 16, 18, 25, 26, 31, 32, 45, 49, 50, 55, 56, 59, 60, 61, 64]; 
         pos_idx = scouts(seed_idx).Vertices;
         pos = vc(pos_idx,:);
-        mid_point = mean(pos,1);
-        [~,closest_pos_idx] = min(eucl(mid_point, pos));
-        coordinate = pos(closest_pos_idx,:);
+        if seed_idx == 1
+            coordinate = vc(736,:);
+        elseif ismember(seed_idx, manual_region_idxs)
+            pos_sorted = sortrows(pos, 3, 'descend'); % sort by descending Z-coordinate
+            coordinate = pos_sorted(1,:);
+        else
+            mid_point = mean(pos,1);
+            [~,closest_pos_idx] = min(eucl(mid_point, pos)); % determine mean voxel
+            coordinate = pos(closest_pos_idx,:);
+        end
     else
         error('Selected region not in cortex')
     end

--- a/roi_connect.m
+++ b/roi_connect.m
@@ -87,8 +87,8 @@ for iroi = 1:nROI
     end
 end
 
-% MIC and MIM use a different function
-if ismember(g.methods, 'MIC') || ismember(g.methods, 'MIM')
+% % MIC and MIM use a different function
+if any(ismember(g.methods, 'MIC')) || any(ismember(g.methods, 'MIM'))
     tmpMethods = setdiff(g.methods, { 'CS' 'COH' 'PSD' 'PSDROI' 'GC' 'TRGC' 'wPLI' 'PDC' 'TRPDC' 'DTF' 'TRDTF' });
     conn_mult = data2sctrgcmim(source_roi_data, EEG.srate, g.morder, 0, g.naccu, [], inds, tmpMethods);
     fields = fieldnames(conn_mult);


### PR DESCRIPTION
- Mainly added GUI implementation for the new visualization options 
- Added documentation
- Seed region can now be plotted on cortex; doesn't work for region 49 yet (we are working on that)
- We surrounded line 91 with `any(...)` in `roi_connect` to make sure that this line is compatible with different Matlab versions 

**Test lines to try out the new functionality:**

`pop_roi_connectplot(EEG, 'measure', 'trgc', 'plotcortex', 'on', 'plotmatrix', 'off', 'freqrange', [4 8], 'plotcortexseedregion', 23);  % cortex seed region, theta band`

`pop_roi_connectplot(EEG, 'measure', 'trgc', 'plotcortex', 'on', 'plotmatrix', 'off', 'freqrange', [4 8], 'plotcortexseedregion', 24);  % cortex seed region, theta band`

<img width="513" alt="Screenshot 2022-06-08 at 17 41 10" src="https://user-images.githubusercontent.com/48970646/172659405-04a2d333-1d16-41d3-9ca4-16180ae993c2.png">

If no index seed region is passed, net connectivity is plotted